### PR TITLE
feat: deploy Renovate CE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: yarn install --immutable
       - name: Check style
         run: yarn run style
+      - name: Test Renovate CE enqueue helper
+        run: yarn run test:enqueue
       - name: Validate Renovate config
         run: yarn run validate
   publish:

--- a/.github/workflows/renovate-ce.yml
+++ b/.github/workflows/renovate-ce.yml
@@ -1,0 +1,40 @@
+name: Enqueue Renovate CE
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: Repositories to enqueue
+        type: choice
+        options: [canary, all]
+        default: canary
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate-ce-enqueue
+  cancel-in-progress: false
+
+jobs:
+  enqueue:
+    name: Enqueue ${{ github.event_name == 'workflow_dispatch' && inputs.scope || 'all' }}
+    if: vars.RENOVATE_CE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Git repository
+        uses: actions/checkout@v7
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+      - name: Enqueue repositories
+        run: node scripts/enqueue-renovate.mjs "$RENOVATE_CE_SCOPE"
+        env:
+          RENOVATE_CE_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.scope || 'all' }}
+          RENOVATE_CE_URL: ${{ vars.RENOVATE_CE_URL }}
+          MEND_RNV_API_SERVER_SECRET: ${{ secrets.MEND_RNV_API_SERVER_SECRET }}

--- a/Dockerfile.renovate
+++ b/Dockerfile.renovate
@@ -1,0 +1,5 @@
+FROM ghcr.io/mend/renovate-ce:15.0.0@sha256:9234d761f2b57a834d9beba7fc0cc58ce81c742825674332c463e7436bd06a27
+
+COPY renovate.config.cjs /usr/src/app/config.js
+
+ENV RENOVATE_CONFIG_FILE=/usr/src/app/config.js

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	},
 	"scripts": {
 		"style": "prettier --check .",
+		"test:enqueue": "node --test scripts/enqueue-renovate.test.mjs",
 		"validate": "renovate-config-validator"
 	},
 	"prettier": "@jonahsnider/prettier-config",

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://railway.com/railway.schema.json",
+	"build": {
+		"builder": "DOCKERFILE",
+		"dockerfilePath": "Dockerfile.renovate",
+		"watchPatterns": ["Dockerfile.renovate", "railway.json", "renovate.config.cjs"]
+	},
+	"deploy": {
+		"healthcheckPath": "/health",
+		"healthcheckTimeout": 300,
+		"restartPolicyType": "ON_FAILURE",
+		"restartPolicyMaxRetries": 10
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -13,3 +13,18 @@ Set your Renovate config to use this config
 	"extends": ["github>jonahsnider/renovate-config"]
 }
 ```
+
+## Self-hosting
+
+Mend Renovate CE runs from `Dockerfile.renovate` on Railway. Its GitHub App is intentionally configured with `onboarding: false` and `requireConfig: "required"`, so repositories without an existing Renovate config are not changed.
+
+The `Enqueue Renovate CE` workflow fans out a `main` push to every enabled repository. A manual run defaults to the `jonahsnider/renovate-config` canary and can be expanded to all repositories. The workflow remains inert until these repository settings exist:
+
+- Secret: `MEND_RNV_API_SERVER_SECRET`
+- Variable: `RENOVATE_CE_URL`
+- Variable: `RENOVATE_CE_ENABLED=true`
+
+During migration, Railway must retain `RENOVATE_IGNORE_PR_AUTHOR=true` until every pull request authored by the hosted `renovate[bot]` is gone. Start with `MEND_RNV_AUTODISCOVER_FILTER=jonahsnider/renovate-config`, `RENOVATE_DRY_RUN=full`, startup enqueueing disabled, and a dormant job schedule. Disable the hosted Renovate installation before the first run without dry-run mode. The production schedule is:
+
+- App sync: `MEND_RNV_CRON_APP_SYNC=7 */4 * * *`
+- Repository jobs: `MEND_RNV_CRON_JOB_SCHEDULER_ALL=17 */4 * * *`

--- a/renovate.config.cjs
+++ b/renovate.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+	onboarding: false,
+	requireConfig: 'required',
+};

--- a/scripts/enqueue-renovate.mjs
+++ b/scripts/enqueue-renovate.mjs
@@ -1,0 +1,70 @@
+import {pathToFileURL} from 'node:url';
+
+export const canaryRepository = 'jonahsnider/renovate-config';
+
+const request = async ({baseUrl, token, fetchImpl}, path, options = {}) => {
+	const response = await fetchImpl(new URL(path, `${baseUrl.replace(/\/$/, '')}/`), {
+		...options,
+		headers: {
+			accept: 'application/json',
+			authorization: `Bearer ${token}`,
+			...options.headers,
+		},
+	});
+
+	const body = await response.json().catch(() => undefined);
+
+	if (!response.ok) {
+		const message = body?.message ?? body?.reason ?? response.statusText;
+		throw new Error(`${options.method ?? 'GET'} ${path} failed (${response.status}): ${message}`);
+	}
+
+	return body;
+};
+
+export const listRepositories = async client => {
+	const repositories = await request(client, '/api/v1/orgs/jonahsnider/-/repos?state=installed&limit=10000');
+
+	if (!Array.isArray(repositories)) {
+		throw new TypeError('Reporting API returned a non-array repository response');
+	}
+
+	return [...new Set(repositories.filter(({enabled}) => enabled).map(({fullName}) => fullName))].sort();
+};
+
+export const enqueueRepositories = async (client, repositories, log = console.log) => {
+	for (const repository of repositories) {
+		const result = await request(client, '/system/v1/jobs/add', {
+			method: 'POST',
+			headers: {'content-type': 'application/json'},
+			body: JSON.stringify({repository}),
+		});
+		log(`${repository}: ${result?.change ?? result?.status ?? 'queued'}`);
+	}
+};
+
+export const run = async ({scope, baseUrl, token, fetchImpl = fetch, log = console.log}) => {
+	if (!['all', 'canary'].includes(scope)) {
+		throw new Error(`Invalid scope: ${scope}`);
+	}
+	if (!baseUrl) {
+		throw new Error('RENOVATE_CE_URL is required');
+	}
+	if (!token) {
+		throw new Error('MEND_RNV_API_SERVER_SECRET is required');
+	}
+
+	const client = {baseUrl, token, fetchImpl};
+	const repositories = scope === 'canary' ? [canaryRepository] : await listRepositories(client);
+
+	log(`Enqueueing ${repositories.length} ${scope} ${repositories.length === 1 ? 'repository' : 'repositories'}`);
+	await enqueueRepositories(client, repositories, log);
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	await run({
+		scope: process.argv[2] ?? 'canary',
+		baseUrl: process.env.RENOVATE_CE_URL,
+		token: process.env.MEND_RNV_API_SERVER_SECRET,
+	});
+}

--- a/scripts/enqueue-renovate.test.mjs
+++ b/scripts/enqueue-renovate.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {canaryRepository, run} from './enqueue-renovate.mjs';
+
+const json = (body, init) => Response.json(body, init);
+
+test('canary enqueues only renovate-config without listing repositories', async () => {
+	const requests = [];
+
+	await run({
+		scope: 'canary',
+		baseUrl: 'https://renovate.example.com',
+		token: 'secret',
+		fetchImpl: async (url, init) => {
+			requests.push({url: url.toString(), init});
+			return json({change: 'inserted'}, {status: 201});
+		},
+		log: () => {},
+	});
+
+	assert.equal(requests.length, 1);
+	assert.equal(requests[0].url, 'https://renovate.example.com/system/v1/jobs/add');
+	assert.equal(requests[0].init.headers.authorization, 'Bearer secret');
+	assert.deepEqual(JSON.parse(requests[0].init.body), {repository: canaryRepository});
+});
+
+test('all lists installed repositories and enqueues each enabled repository once', async () => {
+	const enqueued = [];
+
+	await run({
+		scope: 'all',
+		baseUrl: 'https://renovate.example.com/',
+		token: 'secret',
+		fetchImpl: async (url, init) => {
+			if (init.method === 'POST') {
+				enqueued.push(JSON.parse(init.body).repository);
+				return json({change: 'unchanged'});
+			}
+
+			assert.equal(url.toString(), 'https://renovate.example.com/api/v1/orgs/jonahsnider/-/repos?state=installed&limit=10000');
+			return json([
+				{fullName: 'jonahsnider/zeta', enabled: true},
+				{fullName: 'jonahsnider/disabled', enabled: false},
+				{fullName: 'jonahsnider/alpha', enabled: true},
+				{fullName: 'jonahsnider/alpha', enabled: true},
+			]);
+		},
+		log: () => {},
+	});
+
+	assert.deepEqual(enqueued, ['jonahsnider/alpha', 'jonahsnider/zeta']);
+});
+
+test('fails with the CE response message when a request is rejected', async () => {
+	await assert.rejects(
+		run({
+			scope: 'canary',
+			baseUrl: 'https://renovate.example.com',
+			token: 'secret',
+			fetchImpl: async () => json({message: 'installation does not include repository'}, {status: 404}),
+			log: () => {},
+		}),
+		/installation does not include repository/,
+	);
+});


### PR DESCRIPTION
## Summary
- deploy digest-pinned Mend Renovate CE 15.0.0 on Railway
- configure Postgres-backed canary runtime and guarded enqueue workflow
- add dependency-free enqueue tests and migration runbook

## Validation
- yarn run style
- yarn run test:enqueue
- yarn run validate
- Railway Docker image build succeeded; dry-run health verification is in progress