### PR TITLE
fix: recognize hosted Renovate commits

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,7 @@
 		":automergeBranch",
 		":prNotPending"
 	],
-	"gitIgnoredAuthors": ["114827586+autofix-ci[bot]@users.noreply.github.com"],
+	"gitIgnoredAuthors": ["114827586+autofix-ci[bot]@users.noreply.github.com", "29139614+renovate[bot]@users.noreply.github.com"],
 	"packageRules": [
 		{
 			"groupName": "prisma",

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ The `Enqueue Renovate CE` workflow fans out a `main` push to every enabled repos
 - Variable: `RENOVATE_CE_URL`
 - Variable: `RENOVATE_CE_ENABLED=true`
 
-During migration, Railway must retain `RENOVATE_IGNORE_PR_AUTHOR=true` until every pull request authored by the hosted `renovate[bot]` is gone. Start with `MEND_RNV_AUTODISCOVER_FILTER=jonahsnider/renovate-config`, `RENOVATE_DRY_RUN=full`, startup enqueueing disabled, and a dormant job schedule. Disable the hosted Renovate installation before the first run without dry-run mode. The production schedule is:
+During migration, Railway must retain `RENOVATE_IGNORE_PR_AUTHOR=true` until every pull request authored by the hosted `renovate[bot]` is gone. `renovate.config.cjs` must also retain the hosted bot's commit email in `gitIgnoredAuthors`, so CE can safely update its existing branches. Remove both migration settings after the hosted-bot pull requests are gone. Start with `MEND_RNV_AUTODISCOVER_FILTER=jonahsnider/renovate-config`, `RENOVATE_DRY_RUN=full`, startup enqueueing disabled, and a dormant job schedule. Disable the hosted Renovate installation before the first run without dry-run mode. The production schedule is:
 
 - App sync: `MEND_RNV_CRON_APP_SYNC=7 */4 * * *`
 - Repository jobs: `MEND_RNV_CRON_JOB_SCHEDULER_ALL=17 */4 * * *`

--- a/renovate.config.cjs
+++ b/renovate.config.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+	gitIgnoredAuthors: ['29139614+renovate[bot]@users.noreply.github.com'],
 	onboarding: false,
 	requireConfig: 'required',
 };


### PR DESCRIPTION
## What changed

- recognize commits authored by the hosted `renovate[bot]` in the CE runtime configuration
- retain the existing `autofix-ci` ignored author while adding the hosted Renovate identity to the shared preset
- document when both migration settings should be removed

## Why

`RENOVATE_IGNORE_PR_AUTHOR=true` lets the new GitHub App discover PRs and Dashboards created by the hosted App, but Renovate separately treats branches as modified when their commits have an unrecognized author. The shared preset's existing `gitIgnoredAuthors` array also replaced the global value, so both bot identities need to be present there during migration.

This allows CE to rebase and update the hosted bot's existing branches without treating them as user edits.

## Validation

- `yarn run style`
- `yarn run validate`
- `yarn run test:enqueue`
- `git diff --check origin/main...HEAD`
